### PR TITLE
Fixed install issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"test": "xo"
 	},
 	"files": [
-		"cli.js"
+		"cli.js",
+		"databases.json"
 	],
 	"keywords": [
 		"database",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"bin": "cli.js",
 	"engines": {
-		"node": ">=6"
+		"node": ">=7"
 	},
 	"scripts": {
 		"test": "xo"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"bin": "cli.js",
 	"engines": {
-		"node": ">=7"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo"


### PR DESCRIPTION
I've encountered some errors regarding mis-configurations in the project's `package.json`:
1. `async` and `await` keywords don't work via node v6.11.2-lts (works from node 7 nightly and above only).
2. databases.json is ommited from the `files` section, thus causing an import error when installing via npm, which is the main way that is proposed to install this script (npm leaves out this file on install).
